### PR TITLE
fix: Build failure on Lean 4.10.0

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -23,8 +23,8 @@ def System.FilePath.noExtensionWithSep (p : FilePath) (sep : String) : String :=
   p.withExtension "" |>.toString.replace FilePath.pathSeparator.toString sep
 
 def main (args : List String) : IO UInt32 := do
-  let leanPaths :=
-    if args.isEmpty then ← getTestPathsFromLake else args.map FilePath.mk
+  let leanPaths ←
+    if args.isEmpty then getTestPathsFromLake else pure $ args.map FilePath.mk
   if leanPaths.isEmpty then
     IO.println "No tests to run"
     return 0


### PR DESCRIPTION
Without this patch the build fails with the message:
```
Main.lean:27:25: error: invalid use of `(<- ...)`, must be nested inside a 'do' expression
```
I moved the monadic bind one layer out to resolve this. Seems like the Lean parser has changed a bit from 4.4.0 to 4.10.0 since this error previously did not manifest.