### PR TITLE
feat: Update to Lean 4.12.0

### DIFF
--- a/LSpec/SlimCheck/Checkable.lean
+++ b/LSpec/SlimCheck/Checkable.lean
@@ -495,7 +495,7 @@ proposition where the quantifiers are annotated with `NamedBinder`.
 scoped elab "mk_decorations" : tactic => do
   let goalType ← (← getMainGoal).getType
   if let Expr.app (.const ``Decorations.DecorationsOf ..) body := goalType then
-    closeMainGoal `mk_decorations (addDecorations body)
+    closeMainGoal `SlimCheck.mk_decorations (addDecorations body)
 
 end Decorations
 

--- a/LSpec/SlimCheck/Checkable.lean
+++ b/LSpec/SlimCheck/Checkable.lean
@@ -495,7 +495,7 @@ proposition where the quantifiers are annotated with `NamedBinder`.
 scoped elab "mk_decorations" : tactic => do
   let goalType ← (← getMainGoal).getType
   if let Expr.app (.const ``Decorations.DecorationsOf ..) body := goalType then
-    closeMainGoal (addDecorations body)
+    closeMainGoal `mk_decorations (addDecorations body)
 
 end Decorations
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.4.0-rc1
+leanprover/lean4:v4.12.0


### PR DESCRIPTION
The `closeMainGoal` function requires a tactic name argument in 4.12.0: https://github.com/leanprover/lean4/blob/dc2533473114eb8656439ff2b9335209784aa640/src/Lean/Elab/Tactic/Basic.lean#L413

This would not be backward compatible with v.4.11 and before, so I think this repo should have tags/branches to indicate Lean versions like Mathlib.