### PR TITLE
chore: bump Lean to v4.17.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: "CI"
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: leanprover/lean-action@v1
+        with:
+          build-args: "--wfail"

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "LSpec"
 version = "2.0.0"
-defaultTargets = ["lspec"]
+defaultTargets = ["LSpec"]
 
 [[lean_lib]]
 name = "LSpec"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.16.0
+leanprover/lean4:v4.17.0


### PR DESCRIPTION
Extra:
* Set the `LSpec` lib as the default target
* Add a CI config to run `lean-action`